### PR TITLE
fix: add a not translated word in Japanese

### DIFF
--- a/assets/i18n/ja-JP.json
+++ b/assets/i18n/ja-JP.json
@@ -39,7 +39,7 @@
   "Confirm": "確認",
   "Clear": "引き払う",
   "Search": "検索",
-  "View Data": "查看數據",
+  "View Data": "データを見る",
   "Data": "データ",
   "Samples": "サンプル",
   "Stat": "統計",


### PR DESCRIPTION
"View data" was not translated in i18n file for Japanese, so did it.